### PR TITLE
add year sorted when in category page

### DIFF
--- a/src/components/ArchivesSort.tsx
+++ b/src/components/ArchivesSort.tsx
@@ -31,9 +31,8 @@ export const ArchivesSort: React.SFC<ArchivesSortProps> = ({
     <div>
       {date !== preDate && <ShowYear year={date} />}
       <Link to={`/blogs/${_.kebabCase(title)}`}>
-        <big>{title}</big>
+        <big>{`${title} - ${author} ${date}`}</big>
       </Link>
-      <small>{author}</small>
     </div>
   )
 }

--- a/src/templates/category-template.tsx
+++ b/src/templates/category-template.tsx
@@ -33,9 +33,7 @@ class CategoriesTemplate extends React.Component<CategoriesTemplate, {}> {
               <div key={index}>
                 <ArchivesSort
                   currentPost={singleNode}
-                  preDate={
-                    index < 1 ? "empty" : nodes[index - 1].frontmatter.date
-                  }
+                  preDate={index < 1 ? null : nodes[index - 1].frontmatter.date}
                 />
               </div>
             )

--- a/src/templates/category-template.tsx
+++ b/src/templates/category-template.tsx
@@ -1,30 +1,42 @@
 import { graphql, Link } from "gatsby"
 import * as _ from "lodash"
 import * as React from "react"
+import ArchivesSort from "../components/ArchivesSort"
 import Layout from "../components/Layout"
 
 interface CategoriesTemplate {
   data: {
     allMarkdownRemark: {
-      distinct: string[]
+      nodes: [
+        {
+          frontmatter: {
+            date: string
+            author: string[]
+            title: string
+          }
+        }
+      ]
     }
   }
 }
 
 class CategoriesTemplate extends React.Component<CategoriesTemplate, {}> {
   render() {
-    const { data } = this.props
-    const allTitle = data.allMarkdownRemark.distinct
+    const { nodes } = this.props.data.allMarkdownRemark
 
     return (
       <div>
         <Layout>
-          {allTitle.map((singleTitle, index) => {
+          {nodes.map((singleNode, index) => {
+            const { title, author, date } = singleNode.frontmatter
             return (
               <div key={index}>
-                <Link to={`/blogs/${_.kebabCase(singleTitle)}`}>
-                  {singleTitle}
-                </Link>
+                <ArchivesSort
+                  currentPost={singleNode}
+                  preDate={
+                    index < 1 ? "empty" : nodes[index - 1].frontmatter.date
+                  }
+                />
               </div>
             )
           })}
@@ -38,8 +50,17 @@ export default CategoriesTemplate
 
 export const pageQuery = graphql`
   query catePageQuery($cate: String!) {
-    allMarkdownRemark(filter: { frontmatter: { categories: { eq: $cate } } }) {
-      distinct(field: frontmatter___title)
+    allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
+      filter: { frontmatter: { categories: { eq: $cate } } }
+    ) {
+      nodes {
+        frontmatter {
+          date(formatString: "YYYY")
+          author
+          title
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
Add one more feature, which is when you click one category tags, you can see all the articles are sorted by year. You can see the image below. I am re-using the component called "ArchivesSort" when I use in the 'Archives page'.
<img width="515" alt="Screen Shot 2019-09-03 at 12 50 27" src="https://user-images.githubusercontent.com/45926410/64193214-4f9b7280-ce4a-11e9-92f7-90cec41d4837.png">
