### PR TITLE
add pagination

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -43,6 +43,22 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   const posts = result.data.allMarkdownRemark.edges
   const authors = result.data.allMarkdownRemark.authors
 
+  const postPerPage = 10
+  const numPages = Math.ceil(posts.length / postPerPage)
+
+  Array.from({ length: numPages }).forEach((_, i) => {
+    createPage({
+      path: i === 0 ? `/` : `/${i + 1}`,
+      component: path.resolve("./src/templates/index.tsx"),
+      context: {
+        limit: postPerPage,
+        skip: i * postPerPage,
+        numPages,
+        currentPage: i + 1,
+      },
+    })
+  })
+
   posts.forEach((post, index) => {
     const previous = index === posts.length - 1 ? null : posts[index + 1].node
     const next = index === 0 ? null : posts[index - 1].node

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -33,21 +33,47 @@ interface IndexPageProps {
       edges: Post[]
     }
   }
+  pageContext: {
+    numPages: any
+    currentPage: any
+  }
 }
 
 class IndexPage extends React.Component<IndexPageProps, {}> {
   render() {
     const { data } = this.props
     const posts = data.allMarkdownRemark.edges
+    const { currentPage, numPages } = this.props.pageContext
+    const isLast = currentPage === numPages
+    const nextPage = (currentPage + 1).toString()
+    const prevPage = 1 ? "" : (currentPage - 1).toString()
+    const isFirst = currentPage.toString() == "1"
 
     return (
       <div>
         <Layout>
+          {!isFirst && (
+            <Link to={prevPage} rel="prev">
+              Prev
+            </Link>
+          )}
+
+          {Array.from({ length: numPages }, (_, i) => (
+            <li key={`${i + 1}`} style={{ margin: 15 }}>
+              <Link to={`/${i === 0 ? "" : i + 1}`}>{i + 1}</Link>
+            </li>
+          ))}
+
+          {!isLast && (
+            <Link to={nextPage} rel="next">
+              Next
+            </Link>
+          )}
+
           <SEO
             title="All posts"
             keywords={["artsy", "blog", "gatsby", "javascript", "react"]}
           />
-
           {posts.map(({ node }) => {
             const title = node.frontmatter.title || node.fields.slug
             const authors = node.frontmatter.author
@@ -62,12 +88,14 @@ class IndexPage extends React.Component<IndexPageProps, {}> {
                   <Link to={`/blogs/${_.kebabCase(title)}`}>{title}</Link>
                 </h3>
                 <small>{node.frontmatter.date}</small>
+
                 <br />
 
                 {authors.map((author, index) => {
                   return (
                     <div key={index}>
                       <br />
+
                       <Link
                         to={`/authors/${_.kebabCase(author)}`}
                         onClick={() => {
@@ -93,13 +121,17 @@ class IndexPage extends React.Component<IndexPageProps, {}> {
 export default IndexPage
 
 export const pageQuery = graphql`
-  query {
+  query blogPageQuery($skip: Int!, $limit: Int!) {
     site {
       siteMetadata {
         title
       }
     }
-    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+    allMarkdownRemark(
+      sort: { fields: [frontmatter___date], order: DESC }
+      limit: $limit
+      skip: $skip
+    ) {
       edges {
         node {
           excerpt


### PR DESCRIPTION
Address: 


This PR adds the pagination on the index page. 

The idea is to set up a number in the nodejs file. Then pass that number, and use that number to do the limitation when we are doing the query. Also, the number will be used in showing how many pages we have, and what page we are viewing.

It will just show 10 blog posts per page. On the first page will not "prev"(means you can not go to page 0), and the same thing on the last page(not showing 'next' on the last page, there are no reasons to let you go to the page does not exist).
![pagination](https://user-images.githubusercontent.com/45926410/65349135-b2ae3880-dbb0-11e9-80d7-5634eae02394.gif)